### PR TITLE
Fix item stack subtraction (#1)

### DIFF
--- a/Tiles/Platform.cs
+++ b/Tiles/Platform.cs
@@ -10,23 +10,15 @@ public class Platform : GlobalTile
         var amount = Math.Min(Main.LocalPlayer.HeldItem.stack, 5);
         var heldItem = Main.LocalPlayer.HeldItem;
 
-        if (Main.LocalPlayer.direction == 1)
+        bool directionRight = Main.LocalPlayer.direction == 1;
+
+        heldItem.stack -= (amount - 1);
+        for (int n = 1; n < amount; n++)
         {
-            heldItem.stack -= (amount - 1);
-            for (int n = 1; n < amount; n++)
-            {
-                WorldGen.PlaceTile(i + n, j, item.createTile, style: item.placeStyle);
-                NetMessage.SendTileSquare(Main.LocalPlayer.whoAmI, i + n, j, 1);
-            }
-        }
-        else
-        {
-            heldItem.stack -= (amount - 1);
-            for (int n = 1; n < amount; n++)
-            {
-                WorldGen.PlaceTile(i - n, j, item.createTile, style: item.placeStyle);
-                NetMessage.SendTileSquare(Main.LocalPlayer.whoAmI, i - n, j, 1);
-            }
+            int tilePositionX = directionRight ? i + n : i - n;
+
+            WorldGen.PlaceTile(tilePositionX, j, item.createTile, style: item.placeStyle);
+            NetMessage.SendTileSquare(Main.LocalPlayer.whoAmI, tilePositionX, j, 1);
         }
     }
 }

--- a/Tiles/Platform.cs
+++ b/Tiles/Platform.cs
@@ -7,18 +7,23 @@ public class Platform : GlobalTile
         if (!PlatformHelper.HotkeyPlacePlatform.Current)
             return;
 
-        var amount = Math.Min(Main.LocalPlayer.HeldItem.stack, 5);
         var heldItem = Main.LocalPlayer.HeldItem;
 
-        bool directionRight = Main.LocalPlayer.direction == 1;
-
-        heldItem.stack -= (amount - 1);
-        for (int n = 1; n < amount; n++)
+        for (int n = 0; n < 4; n++)
         {
-            int tilePositionX = directionRight ? i + n : i - n;
+            int tilePositionX = Main.LocalPlayer.direction == 1 ? i + n : i - n;
 
-            WorldGen.PlaceTile(tilePositionX, j, item.createTile, style: item.placeStyle);
+            bool successfullyPlacedTile = WorldGen.PlaceTile(tilePositionX, j, item.createTile, style: item.placeStyle);
             NetMessage.SendTileSquare(Main.LocalPlayer.whoAmI, tilePositionX, j, 1);
+
+            if (!successfullyPlacedTile) continue;
+
+            heldItem.stack--;
+            if (heldItem.stack == 0)
+            {
+                heldItem.TurnToAir();
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
The `bool` result of the `WorldGen.PlaceTile()` call is now used to determine whether the block was placed successfully. The item stack is only subtracted if this evaluates as true. (Fixes #1)